### PR TITLE
rollback problematic changes on simulation_group model

### DIFF
--- a/oplusclient/models/simulation_group.py
+++ b/oplusclient/models/simulation_group.py
@@ -14,17 +14,6 @@ class SimulationGroup(BaseModel):
         super().__init__(endpoint, data)
         self.simulation_endpoint = SimulationEndpoint(self.client, "/simulations", self)
 
-    def _get_result(self, detail_route):
-        if not self.status == "success":
-            raise ValueError(
-                "Results are only available if the simulation group finished successfully. However its status is"
-                f" {self.status}."
-            )
-        download_url = self.detail_action(detail_route)["blob_url"]
-        return pd.read_csv(io.StringIO(self.client.rest_client.download(
-            download_url
-        ).decode("utf-8")))
-
     def run(self, run_old_versions=False, wait_for_start_task=True):
         """
         Run the simulation group.
@@ -105,23 +94,3 @@ class SimulationGroup(BaseModel):
                 return s
         else:
             raise exceptions.RecordNotFoundError(f"There are no simulations in this simulation group with name {name}")
-
-    def get_out_monthly_consumption(self, energy_category="final"):
-        """
-        Parameters
-        ----------
-        energy_category: str, default final
-            final, primary
-
-        Returns
-        -------
-        pd.DataFrame
-        """
-        route = "out_monthly_consumption"
-        if energy_category == "final":
-            route += "_ef"
-        elif energy_category == "primary":
-            route += "_ep"
-        else:
-            raise ValueError(f"Unknown energy category: {energy_category}.")
-        return self._get_result(route)


### PR DESCRIPTION
Rollback changes made to the simulation_group model.

The Simulation Group model is made to access the osssimulation/simulation_groups routes of the API, and can be inherited from by the different types of simulation groups (mono, generic and multi).

The problem is that there are no simulation_groups results available on the osssimulation/simulation_groups API. Simulation group results is a feature that is only available on multi simulation groups (not on generic and mono).
Therefore, calling the _get_results or get_out_monthly_consumption methods on a vanilla / generic / mono simulation group would cause exceptions.

The proper way to access these results is to use the existing MultiSimulationGroup get_out_monthly_consumption_ef and get_out_monthly_consumption_ep methods.